### PR TITLE
主页与账号页展示数据优化

### DIFF
--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -32,9 +32,11 @@ export default function AccountPage() {
     useEffect(() => {
         // 获取账号信息的逻辑
         // 这里的 Token 在 isLogin 校验中判定为非空 那么这里一定不为空
-        fetch('/api/account', {headers: {'Authorization': token.token}})
-            .then(result => result.json() as Promise<Message<Response>>)
-            .then(data => setResult(data.data));
+        if (token && token.token) {
+            fetch('/api/account', {headers: {'Authorization': token.token}})
+                .then(result => result.json() as Promise<Message<Response>>)
+                .then(data => setResult(data.data));
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -46,7 +48,6 @@ export default function AccountPage() {
         document.execCommand('copy');
         document.body.removeChild(input);
     };
-
 
     const [email, setEmail] = useState<string>('');
     const [password, setPassword] = useState<string>('');
@@ -68,6 +69,63 @@ export default function AccountPage() {
                 .then(ignore => 0));
     }
 
+    function renderLogin() {
+        return (
+            <div className="mt-2">
+                <div className="bg-white flex flex-col flex-wrap gap-4 p-16 rounded-2xl"
+                     style={{width: '480px'}}>
+                    <p className="font-bold text-2xl mb-6">登录账号</p>
+                    <Input placeholder="邮箱（未注册将自动注册）" height="48px" width="350px" onChange={setEmail}
+                           onEnterPress={() => {
+                           }}/>
+                    <Input placeholder="密码" height="48px" width="350px" onChange={setPassword}
+                           onEnterPress={() => {
+                           }}/>
+                    <Button text="登录" onclick={login}/>
+                    <Button icon="icons8-github.svg" text="使用 Github 登录" href="/api/oauth"/>
+                </div>
+            </div>
+        )
+    }
+
+    function renderAccount() {
+        return (
+            <div className="flex flex-row justify-center">
+                <div className="bg-white flex flex-col gap-4 p-16 rounded-l-2xl" style={{width: '320px'}}>
+                    <div className="flex flex-col justify-center items-center">
+                        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+                             className="rounded-full" style={{height: '64px', width: '64px'}} alt=""/>
+                    </div>
+                    <Button text="添加一个新的包" onclick={() => router.push("/upload")}/>
+                    <Button text="复制当前账号 TOKEN" onclick={copy}/>
+                    <Button text="退出登录" onclick={() => {
+                        State.clear();
+                        router.push("/").then(ignore => {
+                        })
+                    }}/>
+                </div>
+                <div className="bg-white flex flex-col p-16 rounded-r-2xl" style={{width: '640px'}}>
+                    {
+                        result?.repositories && result.repositories.length > 0
+                            ? result?.repositories.map((repository, index) => {
+                                return (
+                                    <div className=""
+                                         style={{height: '32px'}}
+                                         key={index}>
+                                        <div className="font-bold">`${repository.organization} / ${repository.project}`
+                                        </div>
+                                    </div>
+                                )
+                            })
+                            : <div className="flex justify-center items-center">
+                                <div className="font-bold">暂无包</div>
+                            </div>
+                    }
+                </div>
+            </div>
+        )
+    }
+
     return (
         <main style={{backgroundImage: `url("https://i.im.ge/2023/07/17/5jrzzK.F0ci1uZakAAukOL.jpg")`}}
               className={`flex min-h-screen flex-col ${inter.className} bg-fixed bg-cover bg-center`}>
@@ -75,35 +133,8 @@ export default function AccountPage() {
             <div className="min-h-screen w-full backdrop-blur-2xl flex flex-col gap-2 items-center justify-center">
                 {
                     result
-                        ? <div>
-                            <div className="bg-white flex flex-col gap-4 p-16 rounded-2xl" style={{width: '320px'}}>
-                                <div className="flex flex-col justify-center items-center">
-                                    <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-                                         className="rounded-full" style={{height: '64px', width: '64px'}} alt=""/>
-                                </div>
-                                <Button text="添加一个新的包" onclick={() => router.push("/upload")}/>
-                                <Button text="复制当前账号 TOKEN" onclick={copy}/>
-                                <Button text="退出登录" onclick={() => {
-                                    State.clear();
-                                    router.push("/").then(ignore => {
-                                    })
-                                }}/>
-                            </div>
-                        </div>
-                        : <div className="mt-2">
-                            <div className="bg-white flex flex-col flex-wrap gap-4 p-16 rounded-2xl"
-                                 style={{width: '480px'}}>
-                                <p className="font-bold text-2xl mb-6">登录账号</p>
-                                <Input placeholder="邮箱（未注册将自动注册）" height="48px" width="350px" onChange={setEmail}
-                                       onEnterPress={() => {
-                                       }}/>
-                                <Input placeholder="密码" height="48px" width="350px" onChange={setPassword}
-                                       onEnterPress={() => {
-                                       }}/>
-                                <Button text="登录" onclick={login}/>
-                                <Button icon="icons8-github.svg" text="使用 Github 登录" href="/api/oauth"/>
-                            </div>
-                        </div>
+                        ? renderAccount()
+                        : renderLogin()
                 }
             </div>
         </main>

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -68,6 +68,10 @@ export default function AccountPage() {
                 .then(ignore => 0));
     }
 
+    const update = (org: string, project: string) => {
+        router.push(`/upload?update_organization=${org}&update_project=${project}`).then(ignore => 0);
+    }
+
     function renderLogin() {
         return (
             <div className="mt-2">
@@ -119,7 +123,7 @@ export default function AccountPage() {
                                             <div className=""
                                                  style={{height: '32px'}}
                                                  key={index}
-                                                 onClick={() => router.push(`/upload?update_organization=${repository.organization}&update_project=${repository.project}`)}>
+                                                 onClick={() => update(repository.organization, repository.project)}>
                                                 <div className="font-bold">
                                                     {
                                                         `${repository.organization} / ${repository.project}`

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -32,12 +32,12 @@ export default function AccountPage() {
     useEffect(() => {
         // 获取账号信息的逻辑
         // 这里的 Token 在 isLogin 校验中判定为非空 那么这里一定不为空
-        if (token && token.token) {
-            fetch('/api/account', {headers: {'Authorization': token.token}})
-                .then(result => result.json() as Promise<Message<Response>>)
-                .then(data => setResult(data.data));
-        }
-    }, [token]);
+        fetch('/api/account', {headers: {'Authorization': token.token}})
+            .then(result => result.json() as Promise<Message<Response>>)
+            .then(data => setResult(data.data));
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const copy = () => {
         const input = document.createElement('input');

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -37,8 +37,7 @@ export default function AccountPage() {
                 .then(result => result.json() as Promise<Message<Response>>)
                 .then(data => setResult(data.data));
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [token]);
 
     const copy = () => {
         const input = document.createElement('input');
@@ -132,7 +131,8 @@ export default function AccountPage() {
             <Navbar src={result?.account.avatar}/>
             <div className="min-h-screen w-full backdrop-blur-2xl flex flex-col gap-2 items-center justify-center">
                 {
-                    result
+                    // 获取账号有结果或者本地 localStorage 有 Token
+                    result || token
                         ? renderAccount()
                         : renderLogin()
                 }

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -92,7 +92,9 @@ export default function AccountPage() {
             <div className="flex flex-row justify-center">
                 <div className="bg-white flex flex-col gap-4 p-16 rounded-l-2xl" style={{width: '320px'}}>
                     <div className="flex flex-col justify-center items-center">
-                        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+                        <img src={
+                            result ? result.account.avatar : "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+                        }
                              className="rounded-full" style={{height: '64px', width: '64px'}} alt=""/>
                     </div>
                     <Button text="添加一个新的包" onclick={() => router.push("/upload")}/>
@@ -106,16 +108,28 @@ export default function AccountPage() {
                 <div className="bg-white flex flex-col p-16 rounded-r-2xl" style={{width: '640px'}}>
                     {
                         result?.repositories && result.repositories.length > 0
-                            ? result?.repositories.map((repository, index) => {
-                                return (
-                                    <div className=""
-                                         style={{height: '32px'}}
-                                         key={index}>
-                                        <div className="font-bold">`${repository.organization} / ${repository.project}`
-                                        </div>
-                                    </div>
-                                )
-                            })
+                            ? <div>
+                                <div className="pb-4">
+                                    <p className="text-xl font-bold">创建的包</p>
+                                    <p className="text-sm text-gray-400">点击更新包</p>
+                                </div>
+                                {
+                                    result?.repositories.map((repository, index) => {
+                                        return (
+                                            <div className=""
+                                                 style={{height: '32px'}}
+                                                 key={index}
+                                                 onClick={() => router.push(`/upload?update_organization=${repository.organization}&update_project=${repository.project}`)}>
+                                                <div className="font-bold">
+                                                    {
+                                                        `${repository.organization} / ${repository.project}`
+                                                    }
+                                                </div>
+                                            </div>
+                                        )
+                                    })
+                                }
+                            </div>
                             : <div className="flex justify-center items-center">
                                 <div className="font-bold">暂无包</div>
                             </div>

--- a/src/pages/api/account.ts
+++ b/src/pages/api/account.ts
@@ -23,20 +23,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         // 查询账号信息
         const accounts = new DatabaseService<Account>();
         const id = token.belong;
-        const account = accounts.readAccount(id, AccountType.GITHUB);
+        const account = await accounts.readAccount(id, AccountType.GITHUB);
 
         // 过滤 password 字段
-        // @ts-ignore
-        delete account.password;
+        account[0].password = '';
 
         // 查询仓库列表
         const repositories = new DatabaseService<Repository>();
         const repos = repositories.readRepositoryByAccount(id);
 
+        console.log(repos)
+
         res.status(200).json(new Message(200, 'success.',
             {
                 id: id,
-                account: account,
+                account: account[0],
                 repositories: repos
             }));
     } else res.status(400).json(new Message(400, 'request method not match.', null));

--- a/src/pages/api/account.ts
+++ b/src/pages/api/account.ts
@@ -4,6 +4,8 @@ import CacheService from "@/services/cache";
 import {Token} from "@/common/token";
 import DatabaseService from "@/services/database";
 import {AccountType} from "@/data/account";
+import {Repository} from "@/common/repository";
+import {Account} from "@/common/account";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<{}>) {
     if (req.method === 'GET') {
@@ -19,7 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         const token = await tokens.get(header as string) as Token;
 
         // 查询账号信息
-        const accounts = new DatabaseService();
+        const accounts = new DatabaseService<Account>();
         const id = token.belong;
         const account = accounts.readAccount(id, AccountType.GITHUB);
 
@@ -28,7 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         delete account.password;
 
         // 查询仓库列表
-        const repositories = new DatabaseService();
+        const repositories = new DatabaseService<Repository>();
         const repos = repositories.readRepositoryByAccount(id);
 
         res.status(200).json(new Message(200, 'success.',

--- a/src/pages/api/account.ts
+++ b/src/pages/api/account.ts
@@ -3,7 +3,6 @@ import Message from "@/common/message";
 import CacheService from "@/services/cache";
 import {Token} from "@/common/token";
 import DatabaseService from "@/services/database";
-import {AccountType} from "@/data/account";
 import {Repository} from "@/common/repository";
 import {Account} from "@/common/account";
 
@@ -23,21 +22,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         // 查询账号信息
         const accounts = new DatabaseService<Account>();
         const id = token.belong;
-        const account = await accounts.readAccount(id, AccountType.GITHUB);
-
-        // 过滤 password 字段
-        account[0].password = '';
+        const account = await accounts.readAccountById(id);
 
         // 查询仓库列表
         const repositories = new DatabaseService<Repository>();
-        const repos = repositories.readRepositoryByAccount(id);
-
-        console.log(repos)
+        const repos = await repositories.readRepositoryByAccount(id);
 
         res.status(200).json(new Message(200, 'success.',
             {
                 id: id,
-                account: account[0],
+                account: account.length !== 0 ? account[0] : {},
                 repositories: repos
             }));
     } else res.status(400).json(new Message(400, 'request method not match.', null));

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -92,7 +92,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
         const token = new Token(
             crypto.randomUUID(),
-            account.id,
+            accountInDB.length === 0 ? account.id : accountInDB[0].id,
             TokenType.OAUTH_TOKEN,
             time,
             expire

--- a/src/pages/api/repository.ts
+++ b/src/pages/api/repository.ts
@@ -23,6 +23,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                     : content.replace(/\n/g, "")
 
                 item.readme = content;
+                // @ts-ignore
+                item.tags = item.tags.join(',');
             }
 
             res.status(200).json(

--- a/src/pages/api/repository.ts
+++ b/src/pages/api/repository.ts
@@ -23,6 +23,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                     : content.replace(/\n/g, "")
 
                 item.readme = content;
+                // 将 tags 从字符串转换为数组
+                // @ts-ignore
+                item.tags = item.tags.split(',');
             }
 
             res.status(200).json(

--- a/src/pages/api/repository.ts
+++ b/src/pages/api/repository.ts
@@ -23,8 +23,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                     : content.replace(/\n/g, "")
 
                 item.readme = content;
-                // @ts-ignore
-                item.tags = item.tags.join(',');
             }
 
             res.status(200).json(

--- a/src/pages/components/Row.tsx
+++ b/src/pages/components/Row.tsx
@@ -1,4 +1,4 @@
-import {Component, useState} from "react";
+import {Component} from "react";
 import {withRouter} from "next/router";
 import {WithRouterProps} from "next/dist/client/with-router";
 
@@ -33,7 +33,14 @@ class Row extends Component<RowProps> {
                         this.props.tags && this.props.tags.map && this.props.tags.map((value, index) => {
                             return (
                                 <div key={index} className="bg-gray-200 rounded-full px-2 py-1 text-gray-600 text-sm">
-                                    {value.replace('[', '').replace(']', '').replace(/"/g, '').replace(/,/g, ' ')}
+                                    {
+                                        value.replace('[', '')
+                                            .replace(']', '')
+                                            .replace('{', '')
+                                            .replace('}', '')
+                                            .replace(/"/g, '')
+                                            .replace(/,/g, ' ')
+                                    }
                                 </div>
                             )
                         })

--- a/src/pages/components/Row.tsx
+++ b/src/pages/components/Row.tsx
@@ -33,7 +33,7 @@ class Row extends Component<RowProps> {
                         this.props.tags && this.props.tags.map && this.props.tags.map((value, index) => {
                             return (
                                 <div key={index} className="bg-gray-200 rounded-full px-2 py-1 text-gray-600 text-sm">
-                                    {value}
+                                    {value.replace('[', '').replace(']', '').replace(/"/g, '').replace(/,/g, ' ')}
                                 </div>
                             )
                         })

--- a/src/pages/components/Row.tsx
+++ b/src/pages/components/Row.tsx
@@ -5,16 +5,17 @@ import {WithRouterProps} from "next/dist/client/with-router";
 interface RowProps extends WithRouterProps {
     title: string;
     text: string;
+    tags: string[];
     url: string;
 }
 
 class Row extends Component<RowProps> {
     render() {
         return (
-            <div className="shadow-xl flex justify-center flex-col gap-4 p-4"
+            <div className="shadow-xl flex justify-center flex-col gap-4 p-6"
                  style={{
                      maxWidth: "680px",
-                     height: "180px",
+                     height: "240px",
                      borderRadius: "8px",
                      textOverflow: "ellipsis",
                      overflow: "hidden",
@@ -23,6 +24,17 @@ class Row extends Component<RowProps> {
                  onClick={e => this.props.router.push(this.props.url)}>
                 <p className="text-gray-900 text-lg font-bold">{this.props.title}</p>
                 <p className="text-gray-600 text-sm">{this.props.text}</p>
+                <div className="flex flex-row flex-wrap gap-2">
+                    {
+                        this.props.tags.map((value, index) => {
+                            return (
+                                <div key={index} className="bg-gray-200 rounded-full px-2 py-1 text-gray-600 text-sm">
+                                    {value}
+                                </div>
+                            )
+                        })
+                    }
+                </div>
             </div>
         );
     }

--- a/src/pages/components/Row.tsx
+++ b/src/pages/components/Row.tsx
@@ -1,4 +1,4 @@
-import {Component} from "react";
+import {Component, useState} from "react";
 import {withRouter} from "next/router";
 import {WithRouterProps} from "next/dist/client/with-router";
 
@@ -15,8 +15,6 @@ class Row extends Component<RowProps> {
     }
 
     render() {
-        const tag = new Array(...this.props.tags);
-
         return (
             <div className="shadow-xl flex justify-center flex-col gap-4 p-6"
                  style={{
@@ -32,7 +30,7 @@ class Row extends Component<RowProps> {
                 <p className="text-gray-600 text-sm">{this.props.text}</p>
                 <div className="flex flex-row flex-wrap gap-2">
                     {
-                        tag.map((value, index) => {
+                        this.props.tags && this.props.tags.map((value, index) => {
                             return (
                                 <div key={index} className="bg-gray-200 rounded-full px-2 py-1 text-gray-600 text-sm">
                                     {value}

--- a/src/pages/components/Row.tsx
+++ b/src/pages/components/Row.tsx
@@ -10,7 +10,13 @@ interface RowProps extends WithRouterProps {
 }
 
 class Row extends Component<RowProps> {
+    constructor(props: RowProps) {
+        super(props);
+    }
+
     render() {
+        const tag = new Array(...this.props.tags);
+
         return (
             <div className="shadow-xl flex justify-center flex-col gap-4 p-6"
                  style={{
@@ -26,7 +32,7 @@ class Row extends Component<RowProps> {
                 <p className="text-gray-600 text-sm">{this.props.text}</p>
                 <div className="flex flex-row flex-wrap gap-2">
                     {
-                        this.props.tags.map((value, index) => {
+                        tag.map((value, index) => {
                             return (
                                 <div key={index} className="bg-gray-200 rounded-full px-2 py-1 text-gray-600 text-sm">
                                     {value}

--- a/src/pages/components/Row.tsx
+++ b/src/pages/components/Row.tsx
@@ -30,7 +30,7 @@ class Row extends Component<RowProps> {
                 <p className="text-gray-600 text-sm">{this.props.text}</p>
                 <div className="flex flex-row flex-wrap gap-2">
                     {
-                        this.props.tags && this.props.tags.map((value, index) => {
+                        this.props.tags && this.props.tags.map && this.props.tags.map((value, index) => {
                             return (
                                 <div key={index} className="bg-gray-200 rounded-full px-2 py-1 text-gray-600 text-sm">
                                     {value}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -112,7 +112,7 @@ export default function Home() {
                 </div>
             </div>
             <div className="min-h-screen w-full bg-white flex items-center justify-center">
-                <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl"
+                <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl m-8"
                      style={{minWidth: '680px', minHeight: '480px'}}>
                     {
                         repository.length !== 0
@@ -134,7 +134,7 @@ export default function Home() {
             </div>
             {
                 <div className="min-h-screen w-full bg-white flex items-center justify-center">
-                    <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl"
+                    <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl m-8"
                          style={{minWidth: '680px', minHeight: '480px'}}>
                         <p className="text-xl">eBPF 搜索统计 / 趋势</p>
                     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -117,6 +117,8 @@ export default function Home() {
                     {
                         repository.length !== 0
                             ? repository.map((value, index) => {
+                                console.log(value);
+
                                 return (
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,13 +45,15 @@ export default function Home() {
                     State.token = re.data.token;
                     State.account = re.data.account;
 
-                    return router.push('/account').then(() => {});
+                    return router.push('/account').then(() => {
+                    });
                 }
 
                 if (data.status === 302) {
                     let re = res as Message<string>;
 
-                    return router.push(re.data).then(() => {});
+                    return router.push(re.data).then(() => {
+                    });
                 }
             });
     }
@@ -90,30 +92,31 @@ export default function Home() {
                 </div>
             </div>
             <div className="min-h-screen w-full bg-white flex items-center justify-center">
-                <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl" style={{ width: '90%', minHeight: '500px' }}>
+                <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl"
+                     style={{width: '90%', minHeight: '500px'}}>
                     <p className="text-3xl">eBPF 搜索统计 / 趋势</p>
                     <div className="flex flex-row items-center justify-center gap-16">
-                        <div className="shadow-xl rounded-xl" style={{ width: '48%', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '48%', height: '320px'}}>
 
                         </div>
-                        <div className="shadow-xl rounded-xl" style={{ width: '48%', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '48%', height: '320px'}}>
 
                         </div>
                     </div>
                     <div className="flex flex-row items-center justify-center gap-16 mt-8">
-                        <div className="shadow-xl rounded-xl" style={{ width: '380px', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
 
                         </div>
-                        <div className="shadow-xl rounded-xl" style={{ width: '380px', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
 
                         </div>
-                        <div className="shadow-xl rounded-xl" style={{ width: '380px', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
 
                         </div>
-                        <div className="shadow-xl rounded-xl" style={{ width: '380px', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
 
                         </div>
-                        <div className="shadow-xl rounded-xl" style={{ width: '380px', height: '320px' }}>
+                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
 
                         </div>
                     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,7 +121,10 @@ export default function Home() {
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}
                                          text={value.readme}
-                                         tags={value.tags}
+                                         tags={
+                                             // @ts-ignore
+                                             (value.tags as string).split(',')
+                                         }
                                          url={`/repository?id=${value.id}`}
                                     />
                                 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,6 +121,7 @@ export default function Home() {
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}
                                          text={value.readme}
+                                         tags={value.tags}
                                          url={`/repository?id=${value.id}`}
                                     />
                                 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,7 +121,7 @@ export default function Home() {
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}
                                          text={value.readme}
-                                         tags={JSON.parse(`[${value.tags}]`)}
+                                         tags={JSON.parse(`${value.tags}`)}
                                          url={`/repository?id=${value.id}`}
                                     />
                                 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,7 +121,7 @@ export default function Home() {
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}
                                          text={value.readme}
-                                         tags={JSON.parse(`${value.tags}`)}
+                                         tags={JSON.parse(`[${value.tags}]`)}
                                          url={`/repository?id=${value.id}`}
                                     />
                                 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,11 +3,13 @@ import Navbar from "@/pages/components/Navbar";
 import Button from "@/pages/components/Button";
 import {State} from "@/pages/_app";
 import Input from "@/pages/components/Input";
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {useRouter} from "next/router";
 import Message from "@/common/message";
 import {Account} from "@/common/account";
 import {Token} from "@/common/token";
+import {Repository} from "@/common/repository";
+import Row from "@/pages/components/Row";
 
 const inter = Inter({subsets: ['latin']})
 
@@ -16,11 +18,16 @@ interface LoginResponse {
     token: Token;
 }
 
+interface RepositoryResponse {
+    repository: Repository[];
+}
+
 export default function Home() {
     const router = useRouter();
 
     const [email, setEmail] = useState<string>('');
     const [password, setPassword] = useState<string>('');
+    const [repository, setRepository] = useState<Repository[]>([]);
 
     const login = () => {
         fetch('/api/login',
@@ -58,6 +65,19 @@ export default function Home() {
             });
     }
 
+    useEffect(() => {
+        fetch('/api/repository')
+            .then(res => res.json())
+            .then(res => {
+                let data = res as Message<RepositoryResponse>;
+                if (data.status === 200) {
+                    const repository = data.data.repository;
+
+                    setRepository(repository);
+                }
+            });
+    }, []);
+
     return (
         <main style={{backgroundImage: `url("https://i.im.ge/2023/07/17/5jrzzK.F0ci1uZakAAukOL.jpg")`}}
               className={`flex min-h-screen flex-col ${inter.className} bg-fixed bg-cover bg-center`}>
@@ -93,33 +113,38 @@ export default function Home() {
             </div>
             <div className="min-h-screen w-full bg-white flex items-center justify-center">
                 <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl"
-                     style={{width: '90%', minHeight: '500px'}}>
-                    <p className="text-3xl">eBPF 搜索统计 / 趋势</p>
-                    <div className="flex flex-row items-center justify-center gap-16">
-                        <div className="shadow-xl rounded-xl" style={{width: '48%', height: '320px'}}>
-
-                        </div>
-                        <div className="shadow-xl rounded-xl" style={{width: '48%', height: '320px'}}>
-
-                        </div>
+                     style={{minWidth: '680px', minHeight: '480px'}}>
+                    {
+                        repository.length !== 0
+                            ? repository.map((value, index) => {
+                                return (
+                                    <Row key={index}
+                                         title={`${value.organization}  / ${value.project}`}
+                                         text={value.readme}
+                                         url={`/repository?id=${value.id}`}
+                                    />
+                                )
+                            })
+                            : <div className="flex flex-col items-center justify-center">
+                                <p className="text-2xl">暂无仓库</p>
+                                <p className="text-xl">快去创建一个吧！</p>
+                            </div>
+                    }
+                </div>
+            </div>
+            {
+                <div className="min-h-screen w-full bg-white flex items-center justify-center">
+                    <div className="flex flex-col shadow-xl p-16 gap-8 rounded-xl"
+                         style={{minWidth: '680px', minHeight: '480px'}}>
+                        <p className="text-xl">eBPF 搜索统计 / 趋势</p>
                     </div>
-                    <div className="flex flex-row items-center justify-center gap-16 mt-8">
-                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
-
-                        </div>
-                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
-
-                        </div>
-                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
-
-                        </div>
-                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
-
-                        </div>
-                        <div className="shadow-xl rounded-xl" style={{width: '380px', height: '320px'}}>
-
-                        </div>
-                    </div>
+                </div>
+            }
+            <div className="bg-white">
+                <div className="flex flex-col justify-center items-center p-8 m-8">
+                    <p>Powered By eBPF Hub</p>
+                    <p>Open Source On <a className="text-blue-400"
+                                         href="https://github.com/linuxkerneltravel/ebpfs"> Github </a></p>
                 </div>
             </div>
         </main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,10 +121,7 @@ export default function Home() {
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}
                                          text={value.readme}
-                                         tags={
-                                             // @ts-ignore
-                                             (value.tags as string).split(',')
-                                         }
+                                         tags={JSON.parse(`[${value.tags}]`)}
                                          url={`/repository?id=${value.id}`}
                                     />
                                 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -123,7 +123,7 @@ export default function Home() {
                                     <Row key={index}
                                          title={`${value.organization}  / ${value.project}`}
                                          text={value.readme}
-                                         tags={JSON.parse(`[${value.tags}]`)}
+                                         tags={value.tags}
                                          url={`/repository?id=${value.id}`}
                                     />
                                 )

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -41,6 +41,7 @@ export default function Search() {
                             <Row key=""
                                  title={`${index.organization}  / ${index.project}`}
                                  text={index.content.length > 500 ? index.content.slice(0, 500) : index.content}
+                                 tags={index.tags}
                                  url={`/repository?id=${index.id}`}
                             />
                         ))}

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -14,6 +14,9 @@ export default function UploadPage() {
     }());
 
     const router = useRouter();
+    // 从上一个页面传递的参数
+    // 如果不为 undefined 则为更新仓库
+    const {update_organization, update_project} = router.query;
 
     //
     // 提交仓库表单
@@ -34,6 +37,10 @@ export default function UploadPage() {
     const [author, setAuthor] = useState<string[]>([]);
     // 标签
     const [tags, setTags] = useState<string[]>([]);
+
+    // 预先填入
+    if (update_organization) setOrganization(update_organization as string);
+    if (update_project) setProject(update_project as string);
 
     const token = State.token as Token;
 

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -18,13 +18,16 @@ export default function UploadPage() {
     // 如果不为 undefined 则为更新仓库
     const {update_organization, update_project} = router.query;
 
+    console.log(update_organization)
+    console.log(update_project)
+
     //
     // 提交仓库表单
     //
     // 组织
-    const [organization, setOrganization] = useState<string>('');
+    const [organization, setOrganization] = useState<string>(update_organization ? update_organization as string : '');
     // 项目
-    const [project, setProject] = useState<string>('');
+    const [project, setProject] = useState<string>(update_project ? update_project as string : '');
     // 版本
     const [version, setVersion] = useState<string>('');
     // 仓库
@@ -37,10 +40,6 @@ export default function UploadPage() {
     const [author, setAuthor] = useState<string[]>([]);
     // 标签
     const [tags, setTags] = useState<string[]>([]);
-
-    // 预先填入
-    if (update_organization) setOrganization(update_organization as string);
-    if (update_project) setProject(update_project as string);
 
     const token = State.token as Token;
 
@@ -78,10 +77,10 @@ export default function UploadPage() {
                         <div className="bg-white flex flex-col flex-wrap gap-4 p-16 rounded-2xl"
                              style={{width: '480px'}}>
                             <p className="font-bold text-xl">提交一个仓库 / 更新仓库</p>
-                            <Input placeholder="组织" height="48px" width="350px" onChange={setOrganization}
+                            <Input placeholder={ update_organization ? update_organization as string : '组织'} height="48px" width="350px" onChange={setOrganization}
                                    onEnterPress={() => {
                                    }}/>
-                            <Input placeholder="项目" height="48px" width="350px" onChange={setProject}
+                            <Input placeholder={ update_project ? update_project as string : '项目'} height="48px" width="350px" onChange={setProject}
                                    onEnterPress={() => {
                                    }}/>
                             <Input placeholder="版本" height="48px" width="350px" onChange={setVersion}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -109,10 +109,28 @@ export default class DatabaseService<T> {
             .execute();
     }
 
+    public async readRepositoryByOrganizationAndProject(organization: string, project: string) {
+        return await this.db
+            .selectFrom('repository')
+            .where('organization', '=', organization)
+            .where('project', '=', project)
+            .selectAll()
+            .execute();
+    }
+
     public async readRepositoryByAccount(account: string) {
         return await this.db
             .selectFrom('repository')
             .where('account', '=', account)
+            .selectAll()
+            .execute();
+    }
+
+    public async readRepositoryByLimit(limit: number) {
+        return await this.db
+            .selectFrom('repository')
+            .orderBy('created', 'desc')
+            .limit(limit)
             .selectAll()
             .execute();
     }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -127,11 +127,12 @@ export default class DatabaseService<T> {
     }
 
     public async readRepositoryByLimit(limit: number) {
+        // 选择数据库中前十个数据
         return await this.db
             .selectFrom('repository')
+            .selectAll()
             .orderBy('created', 'desc')
             .limit(limit)
-            .selectAll()
             .execute();
     }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -121,8 +121,8 @@ export default class DatabaseService<T> {
     public async readRepositoryByAccount(account: string) {
         return await this.db
             .selectFrom('repository')
-            .where('account', '=', account)
             .selectAll()
+            .where('account', '=', account)
             .execute();
     }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -66,7 +66,14 @@ export default class DatabaseService<T> {
             .selectFrom('account')
             // 按照类型查询 openid（目前就 Github 一种） 或者 email
             .where(type === AccountType.GITHUB ? 'openid' : 'email', '=', query)
-            .where('type', '=', type)
+            .selectAll()
+            .execute();
+    }
+
+    public async readAccountById(id: string) {
+        return await this.db
+            .selectFrom('account')
+            .where('id', '=', id)
             .selectAll()
             .execute();
     }

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -32,4 +32,28 @@ export default class SearchService {
 
         return index.saveObject(save).wait();
     }
+
+    async update({id, url, organization, project, readme, content, author, tags}: Index) {
+        const client = algoliasearch(this.applicationId, this.apiKey);
+        const index = client.initIndex('docs');
+
+        index.partialUpdateObject({
+            objectID: id,
+            id: id,
+            url: url,
+            organization: organization,
+            project: project,
+            readme: readme,
+            content: content,
+            author: author,
+            tags: tags
+        })
+    }
+
+    async delete(id: string) {
+        const client = algoliasearch(this.applicationId, this.apiKey);
+        const index = client.initIndex('docs');
+
+        return index.deleteObject(id).wait();
+    }
 }


### PR DESCRIPTION
新增：
1. 主页 / 账号页展示对应仓库
2. 已上传以往的 eBPF 包
3. 微调 UI

以下为修复的问题：
1. 修复不能使用组织名和仓库名更新仓库的问题
2. 账号页面因为 Next.js “水合” 不能正常从 localStorage 读取账号信息
3. 搜索页无限请求 Algolia 问题（在上一个 PR 已合并）

正在进行：

- [x]  微调 UI（仓库卡片上仅展示 summary 信息）
- [x]  统计访问数量（需建数据表）
- [x]  微调 UI（仓库卡片展示作者与创建日期等更详细的信息）
- [x]  Github Action 上传 eBPF 包信息
- [x]  更新 README 需增加 /upload API 详细信息
- [ ]  修复 REDIS 数据不会自动过期的问题